### PR TITLE
fix: add id to Set up Python step to fix cache key reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       uses: actions/checkout@v4
       
     - name: Set up Python
+      id: setup-python
       uses: actions/setup-python@v5
       with:
         python-version: '3.14'


### PR DESCRIPTION
The venv cache key referenced `steps.setup-python.outputs.python-version`, but the "Set up Python" step had no `id`, causing the expression to silently fail and produce a malformed cache key.

## Change

- Added `id: setup-python` to the "Set up Python" step in `.github/workflows/ci.yml`

```yaml
- name: Set up Python
  id: setup-python          # <-- added
  uses: actions/setup-python@v5
  with:
    python-version: '3.14'
```

<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for you](https://github.com/RamonAlcantaraArceo/r3a-minikit/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.
