### PR TITLE
Fix release workflow and changelog extraction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         echo "VERSION=$VERSION" >> $GITHUB_ENV
         
         # Extract changelog section for this version
-        awk "/^## \[$VERSION\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md > release_notes.md
+        awk "/^## \[$VERSION\]/{flag=1; next} /^## \[|^\[.*\]: https/{flag=0} flag" CHANGELOG.md > release_notes.md
         
         # Check if release notes were extracted
         if [ ! -s release_notes.md ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Changelog Extraction**: Improved awk script to properly extract release notes without including reference links
+
+### Added
+- **Release Notes**: Clean extraction of changelog sections for GitHub releases without footer links
+
 ## [0.0.1] - 2026-02-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.1] - 2026-02-25
+
+### Added
+- Initial release of r3a-minikit
+- `r3a_logger` package with comprehensive logging utilities
+- `R3ALogger` class for file and console logging with rotation
+- `initialize_logging()` function for simple setup
+- `setup_logging()` function for flexible configuration  
+- `get_current_logger()` and `get_logger()` functions for accessing logger instances
+- Support for Python 3.10-3.14
+- Comprehensive test suite with 100% coverage
+- Multi-version testing with tox
+- CI/CD pipeline with GitHub Actions
+- Code quality enforcement with Ruff and Mypy
+- Coverage reporting with Codecov
+
 ## [0.0.1-beta.3] - 2026-02-25
 
 ### 🧪 Testing Release Infrastructure
@@ -25,22 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This is a **beta release** to validate the complete release infrastructure before the official v0.0.1 release.
 
-## [0.0.1] - 2026-02-25
-
-### Added
-- Initial release of r3a-minikit
-- `r3a_logger` package with comprehensive logging utilities
-- `R3ALogger` class for file and console logging with rotation
-- `initialize_logging()` function for simple setup
-- `setup_logging()` function for flexible configuration  
-- `get_current_logger()` and `get_logger()` functions for accessing logger instances
-- Support for Python 3.10-3.14
-- Comprehensive test suite with 100% coverage
-- Multi-version testing with tox
-- CI/CD pipeline with GitHub Actions
-- Code quality enforcement with Ruff and Mypy
-- Coverage reporting with Codecov
 
 [Unreleased]: https://github.com/RamonAlcantaraArceo/r3a-minikit/compare/v0.0.1...HEAD
-[0.0.1-beta.3]: https://github.com/RamonAlcantaraArceo/r3a-minikit/releases/tag/v0.0.1-beta.3
 [0.0.1]: https://github.com/RamonAlcantaraArceo/r3a-minikit/releases/tag/v0.0.1
+[0.0.1-beta.3]: https://github.com/RamonAlcantaraArceo/r3a-minikit/releases/tag/v0.0.1-beta.3


### PR DESCRIPTION
Fixes release infrastructure issues discovered during beta testing: 

- Fixed GitHub Actions 403 permissions errors
- Improved changelog extraction to exclude reference links  
- Upgraded to action-gh-release@v2
- Auto-detect prereleases from tag patterns
- Added workflow permissions for release creation

Tested with v0.0.1-beta.2 and beta.3 releases. Ready for official v0.0.1 release.